### PR TITLE
README: fix nbviewer links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ notebooks
 
 Some Jupyter Notebooks on geophysics and seismic interpretation.
 
-- [To make a wavelet](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/To_make_a_wavelet.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2013/12/10/to-plot-a-wavelet.html)
-- [To make a wedge](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/To_make_a_wedge.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2013/12/12/to-make-a-wedge.html)
-- [To make up microseismic](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/To_make_up_microseismic.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2013/12/18/to-make-up-microseismic.html)
-- [Filtering horizons](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/Filtering_horizons.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2014/3/6/relentlessly-practical.html)
-- [Mt St Helens](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/Mt_St-Helens.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2014/5/6/how-much-rock-was-erupted-from-mt-st-helens.html)
-- [Slicing seismic](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/Slicing_seismic.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2014/6/16/slicing-seismic-arrays.html)
-- [NMO model](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/NMO_model.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2014/12/11/the-race-for-useful-offsets.html)
-- [Laying out a seismic survey](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/Laying_out_a_seismic_survey.ipynb) — [blog post](http://agilegeoscience.com/journal/2014/12/17/laying-out-a-seismic-survey.html)
-- [Binning a seismic survey](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/Binning_a_seismic_survey.ipynb) — [blog post](http://agilegeoscience.com/blog/2015/1/8/it-goes-in-the-bin)
-- [Query the Rock Property Catalog](http://nbviewer.org/github/agile-geoscience/notebooks/blob/master/Query_the_RPC.ipynb) — [blog post](http://www.agilegeoscience.com/blog/2015/2/24/rock-property-catalog)
+- [To make a wavelet](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/To_make_a_wavelet.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2013/12/10/to-plot-a-wavelet.html)
+- [To make a wedge](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/To_make_a_wedge.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2013/12/12/to-make-a-wedge.html)
+- [To make up microseismic](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/To_make_up_microseismic.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2013/12/18/to-make-up-microseismic.html)
+- [Filtering horizons](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/Filtering_horizons.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2014/3/6/relentlessly-practical.html)
+- [Mt St Helens](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/Mt_St-Helens.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2014/5/6/how-much-rock-was-erupted-from-mt-st-helens.html)
+- [Slicing seismic](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/Slicing_seismic.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2014/6/16/slicing-seismic-arrays.html)
+- [NMO model](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/NMO_model.ipynb) — [blog post](http://www.agilegeoscience.com/journal/2014/12/11/the-race-for-useful-offsets.html)
+- [Laying out a seismic survey](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/Laying_out_a_seismic_survey.ipynb) — [blog post](http://agilegeoscience.com/journal/2014/12/17/laying-out-a-seismic-survey.html)
+- [Binning a seismic survey](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/Binning_a_seismic_survey.ipynb) — [blog post](http://agilegeoscience.com/blog/2015/1/8/it-goes-in-the-bin)
+- [Query the Rock Property Catalog](https://nbviewer.jupyter.org/github/agile-geoscience/notebooks/blob/master/Query_the_RPC.ipynb) — [blog post](http://www.agilegeoscience.com/blog/2015/2/24/rock-property-catalog)
 - [Linear sampling](https://github.com/agile-geoscience/notebooks/blob/master/Linear_sampling.ipynb) — [blog post](http://www.agilegeoscience.com/blog/2015/5/21/the-curse-of-hunting-rare-things)
 - [Burning the ground](https://github.com/agile-geoscience/notebooks/blob/master/burning_ground/Burning%20the%20ground%20Alaska%20blog.ipynb) — [blog post](http://www.agilegeoscience.com/blog/2016/12/15/burning-the-surface-onto-the-subsurface)
 


### PR DESCRIPTION
Alternatively, the links could be changed to point directly to github, since it now renders notebooks. This is the case for the last couple of links already, so it would make the list more consistent.